### PR TITLE
Fix missing catch in promise

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -58,7 +58,7 @@ class SDS011Wrapper extends EventEmitter {
         });
 
         // Queue first command to "warm-up" the connection and command queue
-        this.query();
+        this.query().catch( ex => { console.error('SDS011Wrapper error: ' + ex); } );
     }
 
     /**


### PR DESCRIPTION
Fix crashes when e.g. SDS011 sensor is not connected:
```
(node:3733) UnhandledPromiseRejectionWarning: undefined
(node:3733) UnhandledPromiseRejectionWarning: Unhandled promise
rejection. This error originated either by throwing inside of an async
function without a catch block, or by rejecting a promise which was not
handled with .catch(). (rejection id: 1)
(node:3733) [DEP0018] DeprecationWarning: Unhandled promise rejections
are deprecated. In the future, promise rejections that are not handled
will terminate the Node.js process with a non-zero exit code.
```